### PR TITLE
Fix compilation on ROS Jade

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,16 @@ This repository should be cloned to the `src` directory of your workspace. Alter
 ## Setup
 Copy your network config to `data/yolo.cfg` and network weights as `data/yolo.weights`.
 
+## Message format
+
+For every image received, an [ImageDetections](msg/ImageDetections.msg) message is generated at the `yolo2_detections` topic, containing a Header and a vector of [Detection](msg/Detection.msg). The header time stamp is copied from the received image message; this way, a set of detections can be matched to a specific image. Each [Detection](msg/Detection.msg) contains the following attributes:
+
+* `uint32 class_id` - Class number configured during training;
+* `float32 confidence` - Confidence;
+* `float32 x` - X position of the object's center relative to the image (between 0 = left and 1 = right);
+* `float32 y` - Y position of the object's center relative to the image (between 0 = top and 1 = bottom);
+* `float32 width` - Width of the object relative to the image (between 0 and 1);
+* `float32 height` - Height of the object relative to the image (between 0 and 1).
+
 ## Contributors
 Written by the ThundeRatz robotics team.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Integrates [YOLOv2](http://pjreddie.com/darknet/yolo/) with ROS, generating messages with position and confidence of detection.
 
 ## Requirements
-* ROS (tested on kinetic)
+* ROS (tested on Jade and Kinetic)
 
 * GPU supporting CUDA
 

--- a/msg/ImageDetections.msg
+++ b/msg/ImageDetections.msg
@@ -1,3 +1,2 @@
 Header header
-time image_stamp
 Detection[] detections

--- a/src/darknet/yolo2.cpp
+++ b/src/darknet/yolo2.cpp
@@ -74,7 +74,7 @@ yolo2::ImageDetections Detector::detect(const sensor_msgs::ImageConstPtr& msg)
   image im = convert_image(msg);
   yolo2::ImageDetections detections;
   detections.detections = forward(im.data);
-  detections.image_stamp = msg->header.stamp;
+  detections.header.stamp = msg->header.stamp;
   free_image(im);
   return detections;
 }

--- a/src/darknet/yolo2.cpp
+++ b/src/darknet/yolo2.cpp
@@ -68,7 +68,7 @@ yolo2::ImageDetections Detector::detect(const sensor_msgs::ImageConstPtr& msg)
 {
   if (msg->encoding != sensor_msgs::image_encodings::RGB8)
   {
-    ROS_ERROR("Ignoring unsupported encoding ", msg->encoding);
+    ROS_ERROR("Ignoring unsupported encoding");
     return yolo2::ImageDetections();
   }
   image im = convert_image(msg);


### PR DESCRIPTION
Make ROS_ERROR call compatible with old API

Fix bem simples, com ROS Jade e GCC mais antigo dava erro de compilação ao passar string como argumento extra.