### PR TITLE
Remove predictions average buffer, use parameter server, use private namespace

### DIFF
--- a/include/darknet/yolo2.h
+++ b/include/darknet/yolo2.h
@@ -56,13 +56,8 @@ class Detector
   std::vector<yolo2::Detection> forward(float *data);
 
   network net;
-  static const int FRAMES = 3;
-  std::vector<float *> predictions;
-  std::vector<float> average;
   std::vector<box> boxes;
   std::vector<float *> probs;
-  int prediction_index;
-  bool filled_buffer;
 };
 }  // namespace darknet
 

--- a/include/darknet/yolo2.h
+++ b/include/darknet/yolo2.h
@@ -29,9 +29,8 @@
 #include <yolo2/Detection.h>
 #include <yolo2/ImageDetections.h>
 
-
-#include <vector>
 #include <string>
+#include <vector>
 
 extern "C"
 {
@@ -47,7 +46,7 @@ namespace darknet
 class Detector
 {
  public:
-  Detector(std::string& model_file, std::string& trained_file);
+  Detector(std::string& model_file, std::string& trained_file, double min_confidence, double nms);
   ~Detector();
   yolo2::ImageDetections detect(const sensor_msgs::ImageConstPtr& msg);
 
@@ -55,6 +54,7 @@ class Detector
   image convert_image(const sensor_msgs::ImageConstPtr& msg);
   std::vector<yolo2::Detection> forward(float *data);
 
+  double min_confidence, nms;
   network net;
   std::vector<box> boxes;
   std::vector<float *> probs;

--- a/src/yolo2_node.cpp
+++ b/src/yolo2_node.cpp
@@ -47,16 +47,19 @@ void imageCallback(const sensor_msgs::ImageConstPtr& msg)
 int main(int argc, char **argv)
 {
   ros::init(argc, argv, "yolo2");
-  ros::NodeHandle node;
+  ros::NodeHandle node("~");
 
   const std::string NET_DATA = ros::package::getPath("yolo2") + "/data/";
   std::string config = NET_DATA + "yolo.cfg", weights = NET_DATA + "yolo.weights";
-  darknet::Detector detector(config, weights);
+  double confidence, nms;
+  node.param<double>("confidence", confidence, .8);
+  node.param<double>("nms", nms, .4);
+  darknet::Detector detector(config, weights, confidence, nms);
   yolo = &detector;
 
   image_transport::ImageTransport transport(node);
   image_transport::Subscriber subscriber = transport.subscribe("image", 1, imageCallback);
-  publisher = node.advertise<yolo2::ImageDetections>("yolo2_detections", 20);
+  publisher = node.advertise<yolo2::ImageDetections>("detections", 5);
   ros::spin();
 
   return 0;


### PR DESCRIPTION
Removi o buffer de detecções usado pelo YOLO em vídeos. O programa deles que estou usando como referência mantém um buffer de predição de 3 frames e faz a média entre eles, suponho que como um filtro para evitar falsos positivos, e funciona bem rodando no meu computador. Não sei se vai ficar tão bom na Jetson, já que a taxa de frames é baixa (<5 FPS por enquanto, mas vou tentar otimizar a captura) e o robô é rápido, então o cone muda de lugar toda hora.

Com essa mudança, o programa fica mais parecido com de detecção de imagens individuais. Fora isso, outras mudanças minor foram usar o servidor de parâmetros do ROS (ver https://github.com/ThundeRatz/ThunderTrekking/pull/26/commits/6ef14e8fe300c664491243ec739b51d1d2a3d777) e mover coisas da YOLO para um namespace próprio.