### PR TITLE
Add nodelet, simplify initial memory alocation, fix linter warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,11 @@ if (FORTIFY)
 endif()
 
 find_package(catkin REQUIRED COMPONENTS
-  image_transport message_generation roscpp roslib roslint sensor_msgs std_msgs
+  image_transport message_generation nodelet roscpp roslib roslint sensor_msgs std_msgs
 )
 find_package(CUDA REQUIRED)
 
-roslint_cpp()
+roslint_cpp(include/darknet/yolo2.h src/darknet/yolo2.cpp src/yolo2_node.cpp src/yolo2_nodelet.cpp)
 roslint_add_test()
 
 ## To declare and build messages, services or actions from within this
@@ -73,11 +73,7 @@ include_directories(
   darknet/src
 )
 
-set(CUDA_NVCC_FLAGS -DGPU=1)
-if (${CUDNN})
-  set(CUDA_NVCC_FLAGS -DCUDNN=1)
-endif()
-cuda_add_library(yolo2 STATIC
+cuda_add_library(yolo2
   darknet/src/activation_kernels.cu
   darknet/src/activation_layer.c
   darknet/src/activations.c
@@ -140,6 +136,17 @@ add_executable(yolo2_node
 add_dependencies(yolo2_node yolo2_generate_messages_cpp)
 
 target_link_libraries(yolo2_node
+  yolo2
+  ${catkin_LIBRARIES}
+)
+
+add_library(yolo2_nodelet
+  src/yolo2_nodelet.cpp
+  src/darknet/yolo2.cpp
+)
+add_dependencies(yolo2_nodelet yolo2_generate_messages_cpp)
+
+target_link_libraries(yolo2_nodelet
   yolo2
   ${catkin_LIBRARIES}
 )

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,0 +1,5 @@
+<library path="lib/libyolo2_nodelet">
+  <class name="yolo2/Yolo2Nodelet" type="yolo2::Yolo2Nodelet" base_class_type="nodelet::Nodelet">
+    <description>YOLO2 nodelet.</description>
+  </class>
+</library>

--- a/package.xml
+++ b/package.xml
@@ -15,6 +15,7 @@
 
   <build_depend>image_transport</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>nodelet</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslint</build_depend>
   <build_depend>sensor_msgs</build_depend>
@@ -22,11 +23,12 @@
 
   <run_depend>image_transport</run_depend>
   <run_depend>message_runtime</run_depend>
+  <run_depend>nodelet</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>std_msgs</run_depend>
 
   <export>
-    <!-- Other tools can request additional information be placed here -->
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
   </export>
 </package>

--- a/src/darknet/yolo2.cpp
+++ b/src/darknet/yolo2.cpp
@@ -37,34 +37,43 @@
 extern "C"
 {
 #undef __cplusplus
-#include "detection_layer.h"
-#include "parser.h"
-#include "region_layer.h"
-#include "utils.h"
+#include "detection_layer.h"  // NOLINT(build/include)
+#include "parser.h"  // NOLINT(build/include)
+#include "region_layer.h"  // NOLINT(build/include)
+#include "utils.h"  // NOLINT(build/include)
 #define __cplusplus
 }
 
 namespace darknet
 {
-Detector::Detector(std::string& model_file, std::string& trained_file, double min_confidence, double nms) :
-  min_confidence(min_confidence), nms(nms)
+Detector::Detector(std::string& model_file, std::string& trained_file, double min_confidence, double nms)
 {
-  net = parse_network_cfg(&model_file[0]);
-  load_weights(&net, &trained_file[0]);
-  set_batch_network(&net, 1);
+  load(model_file, trained_file, min_confidence, nms);
+}
 
-  layer output_layer = net.layers[net.n - 1];
-  boxes.resize(output_layer.w * output_layer.h * output_layer.n);
-  probs.resize(output_layer.w * output_layer.h * output_layer.n);
-  for (auto& i : probs)
-    i = (float *)calloc(output_layer.classes, sizeof(float));
+void Detector::load(std::string& model_file, std::string& trained_file, double min_confidence, double nms)
+{
+  min_confidence_ = min_confidence;
+  nms_ = nms;
+  net_ = parse_network_cfg(&model_file[0]);
+  load_weights(&net_, &trained_file[0]);
+  set_batch_network(&net_, 1);
+
+  layer output_layer = net_.layers[net_.n - 1];
+  boxes_.resize(output_layer.w * output_layer.h * output_layer.n);
+  probs_.resize(output_layer.w * output_layer.h * output_layer.n);
+  float *probs_mem = static_cast<float *>(calloc(probs_.size() * output_layer.classes, sizeof(float)));
+  for (auto& i : probs_)
+  {
+    i = probs_mem;
+    probs_mem += output_layer.classes;
+  }
 }
 
 Detector::~Detector()
 {
-  for (auto& i : probs)
-    free(i);
-  free_network(net);
+  free(probs_[0]);
+  free_network(net_);
 }
 
 yolo2::ImageDetections Detector::detect(const sensor_msgs::ImageConstPtr& msg)
@@ -91,7 +100,8 @@ image Detector::convert_image(const sensor_msgs::ImageConstPtr& msg)
 
   for (uint32_t line = height; line; line--)
   {
-    for (uint32_t column = width; column; column--) {
+    for (uint32_t column = width; column; column--)
+    {
       for (uint32_t channel = 0; channel < 3; channel++)
         im.data[i + width * height * channel] = data[j++] / 255.;
       i++;
@@ -99,35 +109,35 @@ image Detector::convert_image(const sensor_msgs::ImageConstPtr& msg)
     j += offset;
   }
 
-  image resized = resize_image(im, net.w, net.h);
+  image resized = resize_image(im, net_.w, net_.h);
   free_image(im);
   return resized;
 }
 
 std::vector<yolo2::Detection> Detector::forward(float *data)
 {
-  float *prediction = network_predict(net, data);
-  layer output_layer = net.layers[net.n - 1];
+  float *prediction = network_predict(net_, data);
+  layer output_layer = net_.layers[net_.n - 1];
 
   output_layer.output = prediction;
   if (output_layer.type == DETECTION)
-    get_detection_boxes(output_layer, 1, 1, min_confidence, probs.data(), boxes.data(), 0);
+    get_detection_boxes(output_layer, 1, 1, min_confidence_, probs_.data(), boxes_.data(), 0);
   else if (output_layer.type == REGION)
-    get_region_boxes(output_layer, 1, 1, min_confidence, probs.data(), boxes.data(), 0, 0);
+    get_region_boxes(output_layer, 1, 1, min_confidence_, probs_.data(), boxes_.data(), 0, 0);
   else
     error("Last layer must produce detections\n");
 
   int num_classes = output_layer.classes;
-  do_nms(boxes.data(), probs.data(), output_layer.w * output_layer.h * output_layer.n, num_classes, nms);
+  do_nms(boxes_.data(), probs_.data(), output_layer.w * output_layer.h * output_layer.n, num_classes, nms_);
   std::vector<yolo2::Detection> detections;
-  for (unsigned i = 0; i < probs.size(); i++)
+  for (unsigned i = 0; i < probs_.size(); i++)
   {
-    int class_id = max_index(probs[i], num_classes);
-    float prob = probs[i][class_id];
+    int class_id = max_index(probs_[i], num_classes);
+    float prob = probs_[i][class_id];
     if (prob)
     {
       yolo2::Detection detection;
-      box b = boxes[i];
+      box b = boxes_[i];
 
       detection.x = b.x;
       detection.y = b.y;


### PR DESCRIPTION
Umas mudanças pra rodar como nodelet. Tem documentação sobre nodelets aqui: http://wiki.ros.org/nodelet. Basicamente um nodelet funciona como um node, mas pode ser rodado no mesmo processo que outros nodelets, em threads diferentes. O compartilhamento do mesmo processo permite que mensagens sejam trocadas sem passar pelo master do ROS (portanto, sem serem serializadas e transmitidas por TCP).